### PR TITLE
apply config frequency to dataframe

### DIFF
--- a/diive/core/io/filereader.py
+++ b/diive/core/io/filereader.py
@@ -532,6 +532,7 @@ class DataFileReader:
             #     headercols_list = [item.replace(parsed_index_col, f"{parsed_index_col}_ORIGINAL") for item in headercols_list]
 
             data_df.set_index(parsed_index_col, inplace=True)
+            data_df = data_df.asfreq(self.data_freq)
 
         return data_df
 


### PR DESCRIPTION
Hi @holukas 

We had an issue where the inferred time frequency list `freq_list` in `DetectFrequency` has a length of exactly 2 (`["30min", "30T"]`). In that case, the if statement fails, but there is no else and the `inferred_freq` of `TimestampSanitizer` will result to be `None`. 

This small adjustment fixes this since the `DetectFrequency` constructor will never be called because the frequency is already defined on the dataframe index. However, you may want to consider refactor the `DetectFrequency`-class instead. I leave this design choice up to you. :)

